### PR TITLE
3 get api topics

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,0 +1,9 @@
+const request = require("supertest");
+const app = require("../app");
+const seed = require("../db/seeds/seed");
+const data = require("../db/data");
+const db = require("../db");
+
+afterAll(() => db.end());
+beforeEach(() => seed(data));
+

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -33,5 +33,13 @@ describe("/api/topics", () => {
           });
         });
     });
+    test("status: 404 - msg 'Path not found' for invalid endpoint", () => {
+      return request(app)
+        .get("/api/invalid-path")
+        .expect(404)
+        .then(({ body: { msg } }) => {
+          expect(msg).toBe("Path not found");
+        });
+    });
   });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -8,6 +8,16 @@ afterAll(() => db.end());
 beforeEach(() => seed(data));
 
 describe("/api/topics", () => {
+  describe("Cross-method errors", () => {
+    test("status: 404 - msg 'Path not found' for invalid endpoint", () => {
+      return request(app)
+        .get("/api/invalid-path")
+        .expect(404)
+        .then(({ body: { msg } }) => {
+          expect(msg).toBe("Path not found");
+        });
+    });
+  });
   describe("GET", () => {
     test("status: 200 - responds with an array of topic objects", () => {
       return request(app)
@@ -31,14 +41,6 @@ describe("/api/topics", () => {
               })
             );
           });
-        });
-    });
-    test("status: 404 - msg 'Path not found' for invalid endpoint", () => {
-      return request(app)
-        .get("/api/invalid-path")
-        .expect(404)
-        .then(({ body: { msg } }) => {
-          expect(msg).toBe("Path not found");
         });
     });
   });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,9 +1,22 @@
 const request = require("supertest");
 const app = require("../app");
 const seed = require("../db/seeds/seed");
-const data = require("../db/data");
-const db = require("../db");
+const data = require("../db/data/test-data");
+const db = require("../db/connection");
 
 afterAll(() => db.end());
 beforeEach(() => seed(data));
 
+describe("/api/topics", () => {
+  describe("GET", () => {
+    test("status: 200 - responds with an array of topic objects", () => {
+      return request(app)
+        .get("/api/topics")
+        .expect(200)
+        .then(({ body: topics }) => {
+          expect(Array.isArray(topics)).toBe(true);
+          expect(topics).toHaveLength(3);
+        });
+    });
+  });
+});

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -18,5 +18,20 @@ describe("/api/topics", () => {
           expect(topics).toHaveLength(3);
         });
     });
+    test("status: 200 - topic objects in response have 'slug' and 'description' properties with string values", () => {
+      return request(app)
+        .get("/api/topics")
+        .expect(200)
+        .then(({ body: topics }) => {
+          topics.forEach((topic) => {
+            expect(topic).toEqual(
+              expect.objectContaining({
+                slug: expect.any(String),
+                description: expect.any(String),
+              })
+            );
+          });
+        });
+    });
   });
 });

--- a/app.js
+++ b/app.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const { getTopics } = require("./controllers/topics.controllers");
+
+const app = express();
+
+app.get("/api/topics", getTopics);
+
+module.exports = app;

--- a/app.js
+++ b/app.js
@@ -1,8 +1,15 @@
 const express = require("express");
 const { getTopics } = require("./controllers/topics.controllers");
+const { invalidPath } = require("./error-handlers/app.error-handlers");
 
 const app = express();
 
 app.get("/api/topics", getTopics);
+
+app.all("/*", invalidPath);
+
+app.use((err, req, res, next) => {
+  res.status(500).send({ msg: "Internal server error" });
+});
 
 module.exports = app;

--- a/controllers/topics.controllers.js
+++ b/controllers/topics.controllers.js
@@ -1,0 +1,7 @@
+const { fetchTopics } = require("../models/topics.models");
+
+exports.getTopics = (req, res) => {
+  fetchTopics().then((topics) => {
+    res.status(200).send(topics);
+  });
+};

--- a/controllers/topics.controllers.js
+++ b/controllers/topics.controllers.js
@@ -1,7 +1,9 @@
 const { fetchTopics } = require("../models/topics.models");
 
 exports.getTopics = (req, res) => {
-  fetchTopics().then((topics) => {
-    res.status(200).send(topics);
-  });
+  fetchTopics()
+    .then((topics) => {
+      res.status(200).send(topics);
+    })
+    .catch(next);
 };

--- a/error-handlers/app.error-handlers.js
+++ b/error-handlers/app.error-handlers.js
@@ -1,0 +1,3 @@
+exports.invalidPath = (req, res) => {
+  res.status(404).send({ msg: "Path not found" });
+};

--- a/models/topics.models.js
+++ b/models/topics.models.js
@@ -1,0 +1,6 @@
+const db = require("../db/connection");
+
+exports.fetchTopics = async () => {
+  const { rows: topics } = await db.query("SELECT * FROM topics;");
+  return topics;
+};


### PR DESCRIPTION
Happy path tests:
- Responds with array of topics of correct length
- Topics objects have 'slug' and 'description' properties equal to strings
Sad path tests:
- 404 path not found
- Also added handling for 500 internal server error in app.js

Features added:
- app.js set-up
- GET /api/topics endpoint completed
- error-handlers, controllers and models folder structure set-up