### PR TITLE
7 patch articles by article by article_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -150,6 +150,24 @@ describe("/api/articles/:article_id", () => {
           expect(article).toEqual(article1Updated);
         });
     });
+    test("status: 400 - msg 'Missing inc_votes data in request body' for request without inc_votes key in body", () => {
+      return request(app)
+        .patch("/api/articles/1")
+        .send({})
+        .expect(400)
+        .then(({ body: { msg } }) => {
+          expect(msg).toBe("Missing inc_votes data in request body");
+        });
+    });
+    test("status: 400 - msg 'Invalid inc_votes data in request body' for request with invalid inc_votes data type", () =>{
+        return request(app)
+        .patch("/api/articles/1")
+        .send({inc_votes: 'invalid data'})
+        .expect(400)
+        .then(({ body: { msg } }) => {
+          expect(msg).toBe("Invalid inc_votes data in request body");
+        });
+    })
   });
 });
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -128,6 +128,28 @@ describe("/api/articles/:article_id", () => {
           expect(article).toEqual(article1Updated);
         });
     });
+    test("status: 200 - additional data in request body is ignored", () => {
+      const article1Updated = {
+        article_id: 1,
+        title: "Living in the shadow of a great man",
+        topic: "mitch",
+        author: "butter_bridge",
+        body: "I find this existence challenging",
+        created_at: expect.any(String),
+        votes: 200,
+      };
+      return request(app)
+        .patch("/api/articles/1")
+        .send({
+          inc_votes: 100,
+          superfluousData: "Test data",
+          article_id: "superfluous data",
+        })
+        .expect(200)
+        .then(({ body: { article } }) => {
+          expect(article).toEqual(article1Updated);
+        });
+    });
   });
 });
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -159,15 +159,33 @@ describe("/api/articles/:article_id", () => {
           expect(msg).toBe("Missing inc_votes data in request body");
         });
     });
-    test("status: 400 - msg 'Invalid inc_votes data in request body' for request with invalid inc_votes data type", () =>{
-        return request(app)
+    test("status: 400 - msg 'Invalid inc_votes data in request body' for request with invalid inc_votes data type", () => {
+      return request(app)
         .patch("/api/articles/1")
-        .send({inc_votes: 'invalid data'})
+        .send({ inc_votes: "invalid data" })
         .expect(400)
         .then(({ body: { msg } }) => {
           expect(msg).toBe("Invalid inc_votes data in request body");
         });
-    })
+    });
+    test("status: 404 - msg 'Item ID not found' for valid but non-existent article_id", () => {
+      return request(app)
+        .patch("/api/articles/999999")
+        .send({ inc_votes: 10 })
+        .expect(404)
+        .then(({ body: { msg } }) => {
+          expect(msg).toBe("Item ID not found");
+        });
+    });
+    test("status: 400 - msg 'Invalid item ID' for invalid article_id", () => {
+      return request(app)
+        .patch("/api/articles/invalid_id")
+        .send({ inc_votes: 10 })
+        .expect(400)
+        .then(({ body: { msg } }) => {
+          expect(msg).toBe("Invalid item ID");
+        });
+    });
   });
 });
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -81,6 +81,54 @@ describe("/api/articles/:article_id", () => {
         });
     });
   });
+  describe("PATCH", () => {
+    test("status: 200 - increments votes for specified article in database by positive integer passed in request body", () => {
+      return request(app)
+        .patch("/api/articles/1")
+        .send({ inc_votes: 10 })
+        .expect(200)
+        .then(() => {
+          return request(app)
+            .get("/api/articles/1")
+            .expect(200)
+            .then(({ body: { article } }) => {
+              expect(article.votes).toBe(110);
+            });
+        });
+    });
+    test("status: 200 - decrements votes for specified article in database by negative integer passed in request body", () => {
+      return request(app)
+        .patch("/api/articles/1")
+        .send({ inc_votes: -10 })
+        .expect(200)
+        .then(() => {
+          return request(app)
+            .get("/api/articles/1")
+            .expect(200)
+            .then(({ body: { article } }) => {
+              expect(article.votes).toBe(90);
+            });
+        });
+    });
+    test("status: 200 - responds with a single object showing the updated article", () => {
+      const article1Updated = {
+        article_id: 1,
+        title: "Living in the shadow of a great man",
+        topic: "mitch",
+        author: "butter_bridge",
+        body: "I find this existence challenging",
+        created_at: expect.any(String),
+        votes: 200,
+      };
+      return request(app)
+        .patch("/api/articles/1")
+        .send({ inc_votes: 100 })
+        .expect(200)
+        .then(({ body: { article } }) => {
+          expect(article).toEqual(article1Updated);
+        });
+    });
+  });
 });
 
 describe("Invalid endpoint error", () => {

--- a/app.js
+++ b/app.js
@@ -1,6 +1,9 @@
 const express = require("express");
 const { getTopics } = require("./controllers/topics.controllers");
-const { getArticleById } = require("./controllers/articles.controllers");
+const {
+  getArticleById,
+  patchArticleVotes,
+} = require("./controllers/articles.controllers");
 const {
   invalidPath,
   serverError,
@@ -9,10 +12,12 @@ const {
 } = require("./error-handlers/app.error-handlers");
 
 const app = express();
+app.use(express.json());
 
 app.get("/api/topics", getTopics);
 
 app.get("/api/articles/:article_id", getArticleById);
+app.patch("/api/articles/:article_id", patchArticleVotes);
 
 //error handlers
 app.all("/*", invalidPath);

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -19,7 +19,7 @@ exports.patchArticleVotes = (req, res, next) => {
   const { inc_votes } = req.body;
   updateArticleVotes(article_id, inc_votes)
     .then((article) => {
-      res.status(200).send({article});
+      res.status(200).send({ article });
     })
     .catch((err) => {
       next(err);

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -1,10 +1,25 @@
-const { fetchArticleById } = require("../models/articles.models");
+const {
+  fetchArticleById,
+  updateArticleVotes,
+} = require("../models/articles.models");
 
 exports.getArticleById = (req, res, next) => {
   const { article_id } = req.params;
   fetchArticleById(article_id)
     .then((article) => {
       res.status(200).send({ article });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+exports.patchArticleVotes = (req, res, next) => {
+  const { article_id } = req.params;
+  const { inc_votes } = req.body;
+  updateArticleVotes(article_id, inc_votes)
+    .then((article) => {
+      res.status(200).send({article});
     })
     .catch((err) => {
       next(err);

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -9,13 +9,17 @@ exports.fetchArticleById = async (article_id) => {
     WHERE article_id = $1;`,
     [article_id]
   );
+
+  //error handling: no article found
   if (!article) {
     return Promise.reject({ status: 404, msg: "Item ID not found" });
   }
+  
   return article;
 };
 
 exports.updateArticleVotes = async (article_id, inc_votes) => {
+  //error handling: no inc_votes
   if (!inc_votes) {
     return Promise.reject({
       status: 400,
@@ -23,6 +27,7 @@ exports.updateArticleVotes = async (article_id, inc_votes) => {
     });
   }
 
+  //error handling: invalid inc_votes
   if (!Number.isInteger(inc_votes)) {
     return Promise.reject({
       status: 400,
@@ -40,5 +45,11 @@ exports.updateArticleVotes = async (article_id, inc_votes) => {
     RETURNING *;`,
     [article_id, inc_votes]
   );
+
+  //error handling: no article found
+  if (!updatedArticle) {
+    return Promise.reject({ status: 404, msg: "Item ID not found" });
+  }
+
   return updatedArticle;
 };

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -16,6 +16,20 @@ exports.fetchArticleById = async (article_id) => {
 };
 
 exports.updateArticleVotes = async (article_id, inc_votes) => {
+  if (!inc_votes) {
+    return Promise.reject({
+      status: 400,
+      msg: "Missing inc_votes data in request body",
+    });
+  }
+
+  if (!Number.isInteger(inc_votes)) {
+    return Promise.reject({
+      status: 400,
+      msg: "Invalid inc_votes data in request body",
+    });
+  }
+
   const {
     rows: [updatedArticle],
   } = await db.query(

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -14,3 +14,17 @@ exports.fetchArticleById = async (article_id) => {
   }
   return article;
 };
+
+exports.updateArticleVotes = async (article_id, inc_votes) => {
+  const {
+    rows: [updatedArticle],
+  } = await db.query(
+    `
+    UPDATE articles
+    SET votes = votes + $2
+    WHERE article_id = $1
+    RETURNING *;`,
+    [article_id, inc_votes]
+  );
+  return updatedArticle;
+};


### PR DESCRIPTION
This completes the endpoint PATCH /api/articles/:article_id

Happy path tests:
- Able to increment votes by specified number and change is reflected in database
- Able to decrement votes by specified number and change is reflected in database
- Response is the updated article object
- Additional data passed through request body is ignored

Error handling:
- 400 Bad Request for inc_votes key missing from body
- 400 Bad Request for invalid inc_votes data type
- 404 Not Found for valid but non-existent article_id
- 400 Bad Request for invalid article_id

Errors handled with previously built functionality:
- 404 Path Not Found
- 400 Internal Server Error

I'm unsure whether I need to add functionality to handle reducing votes to less than zero. Have thought about:
A. Decrease to zero but no further and respond with 200 and updated article object
B. Respond with 400 Bad Request if the request would take the Votes below zero
C. Do nothing - it's okay for votes to be in negative figures (this is the current functionality)