### PR TITLE
21 GET /api/users

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -211,5 +211,30 @@ describe("/api/users", () => {
           expect(users).toHaveLength(4);
         });
     });
+    test("status: 200 - user objects in response have 'username' property with string value", () => {
+      return request(app)
+        .get("/api/users")
+        .expect(200)
+        .then(({ body: { users } }) => {
+          users.forEach((user) => {
+            expect(user).toEqual(
+              expect.objectContaining({
+                username: expect.any(String),
+              })
+            );
+          });
+        });
+    });
+    test("status: 200 - user objects in response do not have any other properties from the users database", () => {
+      return request(app)
+        .get("/api/users")
+        .expect(200)
+        .then(({ body: { users } }) => {
+          users.forEach((user) => {
+            expect(user).not.toHaveProperty("name");
+            expect(user).not.toHaveProperty("avatar_url");
+          });
+        });
+    });
   });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -225,7 +225,7 @@ describe("/api/users", () => {
           });
         });
     });
-    test("status: 200 - user objects in response do not have any other properties from the users database", () => {
+    test("status: 200 - user objects in response do not contain any other properties from the users table in the database", () => {
       return request(app)
         .get("/api/users")
         .expect(200)

--- a/controllers/users.controllers.js
+++ b/controllers/users.controllers.js
@@ -1,4 +1,4 @@
-const fetchUsers = require("../models/users.models");
+const { fetchUsers } = require("../models/users.models");
 
 exports.getUsers = (req, res, next) => {
   fetchUsers()

--- a/models/users.models.js
+++ b/models/users.models.js
@@ -2,6 +2,6 @@ const db = require("../db/connection");
 
 exports.fetchUsers = async () => {
   const { rows: users } = await db.query(`
-    SELECT * FROM users`);
+    SELECT username FROM users`);
   return users;
 };


### PR DESCRIPTION
Sorry, I accidentally started working on main branch so this PR should also include this as my first commit: https://github.com/Chl0e-g/news-app/commit/5545e1fa25982f4bde86af3c6058f0b17c3e4113

This completes the functionality for /api/users in ticket #21. I've tested for:

Happy path:
- Status 200
- Responds with object containing array of user objects - array is correct length
- User objects contain 'username' property with string value
- User objects do not contain other properties from the users table in the database ('name' or 'avatar_url')

Errors are covered by previous functionality:
- 404 Invalid end point
- 500 Internal server error