### PR TITLE
5 GET /api/articles/:article_id (comment count)

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -58,7 +58,7 @@ describe("/api/articles/:article_id", () => {
           expect(article.article_id).toBe(1);
         });
     });
-    test("status: 200 - article object in response has these properties: author, title, article_id, body, topic, created_at, votes", () => {
+    test("status: 200 - article object in response has these properties: author, title, article_id, body, topic, created_at, votes, comment_count", () => {
       const article1 = {
         article_id: 1,
         title: "Living in the shadow of a great man",
@@ -67,6 +67,7 @@ describe("/api/articles/:article_id", () => {
         body: "I find this existence challenging",
         created_at: expect.any(String),
         votes: 100,
+        comment_count: 11
       };
       return request(app)
         .get("/api/articles/1")

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -58,7 +58,7 @@ describe("/api/articles/:article_id", () => {
           expect(article.article_id).toBe(1);
         });
     });
-    test("status: 200 - article object in response has these properties: author, title, article_id, body, topic, created_at, votes, comment_count", () => {
+    test("status: 200 - article object in response has these properties: author, title, article_id, body, topic, created_at, votes", () => {
       const article1 = {
         article_id: 1,
         title: "Living in the shadow of a great man",
@@ -76,6 +76,22 @@ describe("/api/articles/:article_id", () => {
           expect(article).toEqual(article1);
         });
     });
+    test("status: 200 - article object in response has comment_count property equal to the number of comments associated with that article_id", () => {
+          return request(app)
+            .get("/api/articles/1")
+            .expect(200)
+            .then(({ body: { article } }) => {
+              expect(article.comment_count).toBe(11);
+            });
+    })
+    test("status: 200 - comment_count property is equal to zero if no comments are associated with that article_id", () => {
+        return request(app)
+          .get("/api/articles/2")
+          .expect(200)
+          .then(({ body: { article } }) => {
+            expect(article.comment_count).toBe(0);
+          });
+  })
     test("status: 404 - msg 'Item ID not found' for valid but non-existent article_id", () => {
       return request(app)
         .get("/api/articles/999999")

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -5,8 +5,11 @@ exports.fetchArticleById = async (articleId) => {
     rows: [article],
   } = await db.query(
     `
-    SELECT * FROM articles
-    WHERE article_id = $1;`,
+    SELECT articles.*, COUNT(comments.comment_id)::int AS comment_count 
+    FROM articles
+    JOIN comments ON articles.article_id = comments.article_id
+    WHERE articles.article_id = $1
+    GROUP BY articles.article_id;`,
     [articleId]
   );
 

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -4,26 +4,34 @@ exports.fetchArticleById = async (articleId) => {
   const articleData = db.query(
     `
     SELECT * FROM articles
-    WHERE articles.article_id = $1`,
+    WHERE articles.article_id = $1;`,
     [articleId]
   );
-  const commentCount = db.query(`
+  const commentCount = db.query(
+    `
   SELECT COUNT(*)::int AS comment_count 
   FROM comments
-  WHERE comments.article_id = $1`,
-  [articleId])
+  WHERE comments.article_id = $1;`,
+    [articleId]
+  );
 
-  const [{rows: [article]}, {rows: [{comment_count}]}] = await Promise.all([articleData, commentCount])
+  const [
+    {
+      rows: [article],
+    },
+    {
+      rows: [{ comment_count }],
+    },
+  ] = await Promise.all([articleData, commentCount]);
 
-  
   //error handling: no article found
   if (!article) {
     return Promise.reject({ status: 404, msg: "Item ID not found" });
   }
-  
+
   //adding comment_count to article object
-  article.comment_count = comment_count
-  
+  article.comment_count = comment_count;
+
   return article;
 };
 
@@ -68,6 +76,6 @@ exports.fetchArticles = async () => {
   SELECT 
   author, title, article_id, topic, created_at, votes
   FROM articles
-  ORDER BY created_at DESC`);
+  ORDER BY created_at DESC;`);
   return articles;
 };

--- a/models/users.models.js
+++ b/models/users.models.js
@@ -2,6 +2,6 @@ const db = require("../db/connection");
 
 exports.fetchUsers = async () => {
   const { rows: users } = await db.query(`
-    SELECT * FROM users`);
+    SELECT * FROM users;`);
   return users;
 };


### PR DESCRIPTION
This pull request contains:
- Refactored previous test to expect the response object to include a comment_count property equal to the total number of comments for the specified article
- Refactored database query in model to return comment_count