### PR TITLE
10 GET /api/articles (comment count)

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -67,7 +67,7 @@ describe("/api/articles/:article_id", () => {
         body: "I find this existence challenging",
         created_at: expect.any(String),
         votes: 100,
-        comment_count: 11
+        comment_count: 11,
       };
       return request(app)
         .get("/api/articles/1")
@@ -77,21 +77,21 @@ describe("/api/articles/:article_id", () => {
         });
     });
     test("status: 200 - article object in response has comment_count property equal to the number of comments associated with that article_id", () => {
-          return request(app)
-            .get("/api/articles/1")
-            .expect(200)
-            .then(({ body: { article } }) => {
-              expect(article.comment_count).toBe(11);
-            });
-    })
+      return request(app)
+        .get("/api/articles/1")
+        .expect(200)
+        .then(({ body: { article } }) => {
+          expect(article.comment_count).toBe(11);
+        });
+    });
     test("status: 200 - comment_count property is equal to zero if no comments are associated with that article_id", () => {
-        return request(app)
-          .get("/api/articles/2")
-          .expect(200)
-          .then(({ body: { article } }) => {
-            expect(article.comment_count).toBe(0);
-          });
-  })
+      return request(app)
+        .get("/api/articles/2")
+        .expect(200)
+        .then(({ body: { article } }) => {
+          expect(article.comment_count).toBe(0);
+        });
+    });
     test("status: 404 - msg 'Item ID not found' for valid but non-existent article_id", () => {
       return request(app)
         .get("/api/articles/999999")
@@ -242,6 +242,20 @@ describe("/api/articles", () => {
                 topic: expect.any(String),
                 created_at: expect.any(String),
                 votes: expect.any(Number),
+              })
+            );
+          });
+        });
+    });
+    test("status: 200 - article objects in response have comment_count property equal to the number of comments associated with that article_id", () => {
+      return request(app)
+        .get("/api/articles")
+        .expect(200)
+        .then(({ body: { articles } }) => {
+          articles.forEach((article) => {
+            expect(article).toEqual(
+              expect.objectContaining({
+                comment_count: expect.any(Number),
               })
             );
           });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -258,6 +258,12 @@ describe("/api/articles", () => {
                 comment_count: expect.any(Number),
               })
             );
+            if (article.article_id === 1) {
+              expect(article.comment_count).toBe(11);
+            }
+            if (article.article_id === 2) {
+              expect(article.comment_count).toBe(0);
+            }
           });
         });
     });

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -74,8 +74,11 @@ exports.updateArticleVotes = async (articleId, incVotes) => {
 exports.fetchArticles = async () => {
   const { rows: articles } = await db.query(`
   SELECT 
-  author, title, article_id, topic, created_at, votes
+  articles.author, articles.title, articles.article_id, articles.topic, articles.created_at, articles.votes, COUNT(comments.comment_id)::int AS comment_count
   FROM articles
+  LEFT JOIN comments ON articles.article_id = comments.article_id
+  GROUP BY articles.article_id
   ORDER BY created_at DESC;`);
+  console.log(articles)
   return articles;
 };


### PR DESCRIPTION
This adds the comment_count to the article objects in the response.
I have tested:
- Each article object has a comment_count property equal to any number
- The comment_count number is correct for an article with comments
- The comment_count number is zero for an article without comments