### PR TITLE
12 delete comment

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -586,3 +586,22 @@ describe("/api/articles/:article_id/comments", () => {
     });
   });
 });
+
+describe("/api/comments/:comment_id", () => {
+  describe("DELETE", () => {
+    test("status: 204 - specified comment is deleted from database", () => {
+      return request(app)
+      .delete("/api/comments/1")
+      .expect(204)
+      .then(()=>{
+        //test article that comment 1 belongs to has one fewer comment:
+        return request(app)
+        .get("/api/articles/9")
+        .expect(200)
+      })
+      .then(({body: {article}})=>{
+        expect(article.comment_count).toBe(1)
+      })
+    })
+  });
+});

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -591,17 +591,39 @@ describe("/api/comments/:comment_id", () => {
   describe("DELETE", () => {
     test("status: 204 - specified comment is deleted from database", () => {
       return request(app)
-      .delete("/api/comments/1")
-      .expect(204)
-      .then(()=>{
-        //test article that comment 1 belongs to has one fewer comment:
-        return request(app)
-        .get("/api/articles/9")
-        .expect(200)
-      })
-      .then(({body: {article}})=>{
-        expect(article.comment_count).toBe(1)
-      })
-    })
+        .delete("/api/comments/1")
+        .expect(204)
+        .then(() => {
+          //test article that comment 1 belongs to has one fewer comment:
+          return request(app).get("/api/articles/9").expect(200);
+        })
+        .then(({ body: { article } }) => {
+          expect(article.comment_count).toBe(1);
+        });
+    });
+    test("status: 204 - response body is empty", () => {
+      return request(app)
+        .delete("/api/comments/1")
+        .expect(204)
+        .then(({ body }) => {
+          expect(body).toEqual({});
+        });
+    });
+    test("status 404 - msg 'Comment ID not found' for valid but non-existent comment ID", () => {
+      return request(app)
+        .delete("/api/comments/9999")
+        .expect(404)
+        .then(({ body: { msg } }) => {
+          expect(msg).toBe("Comment ID not found");
+        });
+    });
+    test("status 400 - msg 'Invalid comment ID' for invalid comment ID", () => {
+      return request(app)
+        .delete("/api/comments/invalid-comment-id")
+        .expect(400)
+        .then(({ body: { msg } }) => {
+          expect(msg).toBe("Invalid comment ID");
+        });
+    });
   });
 });

--- a/app.js
+++ b/app.js
@@ -13,7 +13,8 @@ const {
   serverError,
 } = require("./error-handlers/app.error-handlers");
 const {
-  getCommentsByArticleId, postComment
+  getCommentsByArticleId,
+  postComment, deleteComment
 } = require("./controllers/comments.controllers");
 
 const app = express();
@@ -29,6 +30,7 @@ app.get("/api/users", getUsers);
 
 app.get("/api/articles/:article_id/comments", getCommentsByArticleId);
 app.post("/api/articles/:article_id/comments", postComment);
+app.delete("/api/comments/:comment_id", deleteComment);
 
 //error handlers
 app.all("/*", invalidPath);

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -37,7 +37,7 @@ exports.deleteComment = (req, res, next) => {
 
   removeComment(commentId)
     .then(() => {
-      res.status(204).send();
+      res.sendStatus(204)
     })
     .catch((err) => {
       next(err);

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -1,6 +1,7 @@
 const {
   fetchCommentsByArticleId,
   insertComment,
+  removeComment,
 } = require("../models/comments.models");
 const { checkArticleExists } = require("../models/utils.models");
 
@@ -25,6 +26,18 @@ exports.postComment = (req, res, next) => {
   insertComment(articleId, author, body)
     .then((comment) => {
       res.status(200).send({ comment });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+exports.deleteComment = (req, res, next) => {
+  const { comment_id: commentId } = req.params;
+
+  removeComment(commentId)
+    .then(() => {
+      res.status(204).send();
     })
     .catch((err) => {
       next(err);

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -23,3 +23,13 @@ exports.insertComment = async (articleId, author, body) => {
   );
   return comment;
 };
+
+exports.removeComment = async (commentId) => {
+  await db.query(
+    `
+  DELETE FROM comments
+  WHERE comment_id = $1;`,
+    [commentId]
+  );
+  return;
+};

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -25,11 +25,22 @@ exports.insertComment = async (articleId, author, body) => {
 };
 
 exports.removeComment = async (commentId) => {
-  await db.query(
+  //error handling: invalid commentId
+  if (!Number.isInteger(+commentId)) {
+    return Promise.reject({ status: 400, msg: "Invalid comment ID" });
+  }
+
+  const { rowCount } = await db.query(
     `
   DELETE FROM comments
   WHERE comment_id = $1;`,
     [commentId]
   );
+
+  //error handling: commentId not found
+  if (rowCount === 0) {
+    return Promise.reject({ status: 404, msg: "Comment ID not found" });
+  }
+
   return;
 };


### PR DESCRIPTION
This completes the endpoint DELETE /api/comments/:comment_id

I've tested for:
- 204
- comment is deleted from database
- response body is empty

And these errors:
- 404 comment not found for valid but non-existent comment_id
- 400 invalid comment id